### PR TITLE
[feature] print QOL improvements

### DIFF
--- a/app/quotations/create/form.tsx
+++ b/app/quotations/create/form.tsx
@@ -158,6 +158,7 @@ export default function Form(
   const componentRef = useRef(null);
   const handlePrint = useReactToPrint({
     content: () => componentRef.current,
+    documentTitle: "Quotation-" + doc_num
   });
 
 
@@ -166,14 +167,14 @@ export default function Form(
     <div ref={componentRef}>
       <LocalizationProvider dateAdapter={AdapterDayjs}>
         <form >
-          <div className="w-11/12 mx-auto p-2 m-10 mt-2 mb-0 pb-0 flex flex-row justify-between">
+          <div className="w-11/12 print:w-12/12 mx-auto p-2 m-10 mt-2 mb-0 pb-0 flex flex-row justify-between">
             <div className="">
-              <div className="text-left text-2xl">{(pathname.includes('/details/') ? "Quotation Details" : "Create Quotation")}</div>
+              <div className="text-left text-2xl print:">{(pathname.includes('/details/') ? "Quotation Details" : "Create Quotation")}</div>
               <div className="text-primary inline-block text-xl">No. {doc_num}
               </div>
             </div>
 
-            <div className="grid grid-cols-3 gap-2">
+            <div className="grid grid-cols-3 gap-2 print:hidden">
               <button type="button" className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-20 rounded-3xl" onClick={handlePrint}>Print this out!</button>
               <div>
                 <a href="/quotations">
@@ -201,7 +202,7 @@ export default function Form(
               </div>
             </div>
           </div>
-          <div className="w-9/12 mx-auto p-4 m-10 mt-0 bg-white shadow-md rounded-md border">
+          <div className="w-9/12 print:w-11/12 mx-auto p-4 m-2 bg-white shadow-md rounded-md border">
             <div className="m-5 mt-0 flex flex-row justify-between space-x-5">
               <div className="w-1/2 ">
                 <div className="mb-4 w-1/2 space-y-2">
@@ -268,7 +269,7 @@ export default function Form(
 
 
           </div>
-          <div className="w-9/12 mx-auto p-4 m-10 bg-card shadow-md rounded-md border">
+          <div className="w-9/12 print:w-11/12 mx-auto p-4 m-2 bg-card shadow-md rounded-md border">
             <div className="flex flex-row space-x-3">
               <div className="mb-4 w-9/12">
                 <div className="flex flex-row space-x-1 items-center">
@@ -304,7 +305,7 @@ export default function Form(
             </div>
           </div>
 
-          <div className="w-9/12 mx-auto pb-10 bg-card grid grid-flow-col gap-4 ">
+          <div className="w-9/12 print:w-11/12 mx-auto pb-10 bg-card grid grid-flow-col gap-4 ">
             <div className="flex flex-col col-span-1 space-y-5">
               <div className="">
                 <Textarea placeholder="Remarks"></Textarea>
@@ -315,7 +316,7 @@ export default function Form(
               <div className="border rounded-lg">
                 <div className="m-5 flex flex-row justify-between">
                   <label htmlFor="image">Image:</label>
-                  <input id="image" type="file" className="" />
+                  <input id="image" type="file" />
                 </div>
               </div>
               <div className=" flex flex-row space-x-3 items-center">


### PR DESCRIPTION
1. Print styling (hide elements, enlarge on print)

```
<div className="print:hidden>
I want to hide this on PDF
</div>

<div className="w-9/12 print:w-11/12">
Please make it bigger on PDF
</div>
```
2. Print file name now incl. Running number
```

const handlePrint = useReactToPrint({
    content: () => componentRef.current,
    documentTitle: "Quotation-" + doc_num
});

```

<html><body>
<!--StartFragment--><span><h2 id="user-content-api"><a class="heading-link" href="https://www.npmjs.com/package/react-to-print#api">API</a></h2></span><span><h3 id="user-content-reacttoprint-"><a class="heading-link" href="https://www.npmjs.com/package/react-to-print#reacttoprint-">&lt;ReactToPrint /&gt;</a></h3></span><span><p>The component accepts the following props:</p>

Name | Type | Description
-- | -- | --
bodyClass? | string | One or more class names to pass to the print window, separated by spaces
content | function | A function that returns a component reference value. The content of this reference value is then used for print
copyStyles? | boolean | Copy all <style> and <link type="stylesheet" /> tags from <head> inside the parent window into the print window. (default: true)
documentTitle? | string | Set the title for printing when saving as a file
fonts? | { family: string, source: string; weight?: string; style?: string; }[] | You may optionally provide a list of fonts which will  be loaded into the printing iframe. This is useful if you are using  custom fonts
onAfterPrint? | function | Callback function that triggers after the print dialog is closed regardless of if the user selected to print or cancel
onBeforeGetContent? | function | Callback function that triggers before the library  gathers the page's content. Either returns void or a Promise. This can  be used to change the content on the page before printing
onBeforePrint? | function | Callback function that triggers before print. Either  returns void or a Promise. Note: this function is run immediately prior  to printing, but after the page's content has been gathered. To modify  content before printing, use onBeforeGetContent instead
onPrintError? | function | Callback function (signature: function(errorLocation: 'onBeforePrint' \| 'onBeforeGetContent' \| 'print', error: Error))  that will be called if there is a printing error serious enough that  printing cannot continue. Currently limited to Promise rejections in onBeforeGetContent, onBeforePrint, and print. Use this to attempt to print again. errorLocation will tell you in which callback the Promise was rejected
pageStyle? | string or function | We set some basic styles to help improve page printing.  Use this to override them and provide your own. If given as a function  it must return a string
print? | function | If passed, this function will be used instead of window.print to print the content. This function is passed the HTMLIFrameElement  which is the iframe used internally to gather content for printing.  When finished, this function must return a Promise. Use this to print in  non-browser environments such as Electron
removeAfterPrint? | boolean | Remove the print iframe after action. Defaults to false
suppressErrors? | boolean | When passed, prevents console logging of errors
trigger? | function | A function that returns a React Component or Element. Note: under the hood, we inject a custom onClick prop into the returned Component/Element. As such, do not provide an onClick prop to the root node returned by trigger, as it will be overwritten
nonce? | string | Set the nonce attribute for whitelisting script and style -elements for CSP (content security policy)

</span><!--EndFragment-->
</body>
</html>
Reference: 
<a class="heading-link" href="https://www.npmjs.com/package/react-to-print#api">https://www.npmjs.com/package/react-to-print#api</a>
